### PR TITLE
Add Sequelize authentication with role checks

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -5,12 +5,12 @@ const { signToken } = require('../utils/jwt');
 exports.register = async (req, res) => {
   const { name, email, password, role } = req.body;
   try {
-    const existing = await User.findOne({ email });
+    const existing = await User.findOne({ where: { email } });
     if (existing) return res.status(400).json({ message: 'Email already registered' });
 
     const hashed = await bcrypt.hash(password, 10);
     const user = await User.create({ name, email, password: hashed, role });
-    const token = signToken({ id: user._id, role: user.role });
+    const token = signToken({ id: user.id, role: user.role });
     res.status(201).json({ token });
   } catch (err) {
     res.status(500).json({ message: 'Registration error' });
@@ -20,13 +20,13 @@ exports.register = async (req, res) => {
 exports.login = async (req, res) => {
   const { email, password } = req.body;
   try {
-    const user = await User.findOne({ email });
+    const user = await User.findOne({ where: { email } });
     if (!user) return res.status(401).json({ message: 'Invalid credentials' });
 
     const match = await bcrypt.compare(password, user.password);
     if (!match) return res.status(401).json({ message: 'Invalid credentials' });
 
-    const token = signToken({ id: user._id, role: user.role });
+    const token = signToken({ id: user.id, role: user.role });
     res.json({ token });
   } catch (err) {
     res.status(500).json({ message: 'Login error' });

--- a/backend/index.js
+++ b/backend/index.js
@@ -21,10 +21,14 @@ const sequelize = new Sequelize({
   storage: './database.sqlite'
 });
 
-// Probar conexión a la base de datos
+// Probar conexión a la base de datos y sincronizar modelos
 sequelize.authenticate()
   .then(() => {
     console.log('✅ Conectado a la base de datos SQLite');
+    return sequelize.sync();
+  })
+  .then(() => {
+    console.log('📦 Modelos sincronizados');
   })
   .catch(err => {
     console.error('❌ Error al conectar a SQLite:', err);

--- a/backend/middleware/authMiddleware.js
+++ b/backend/middleware/authMiddleware.js
@@ -8,7 +8,9 @@ async function verifyTokenMiddleware(req, res, next) {
 
   try {
     const decoded = verifyToken(token);
-    const user = await User.findById(decoded.id).select('-password');
+    const user = await User.findByPk(decoded.id, {
+      attributes: { exclude: ['password'] }
+    });
     if (!user) return res.status(401).json({ message: 'Invalid token' });
     req.user = user;
     next();

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -1,10 +1,28 @@
-const mongoose = require('mongoose');
+const { DataTypes } = require('sequelize');
+const { sequelize } = require('../index');
 
-const userSchema = new mongoose.Schema({
-  name: { type: String, required: true },
-  email: { type: String, required: true, unique: true },
-  password: { type: String, required: true },
-  role: { type: String, enum: ['admin', 'editor'], default: 'editor' }
+const User = sequelize.define('User', {
+  name: {
+    type: DataTypes.STRING,
+    allowNull: false,
+  },
+  email: {
+    type: DataTypes.STRING,
+    allowNull: false,
+    unique: true,
+  },
+  password: {
+    type: DataTypes.STRING,
+    allowNull: false,
+  },
+  role: {
+    type: DataTypes.STRING,
+    allowNull: false,
+    defaultValue: 'editor',
+    validate: {
+      isIn: [['admin', 'editor']],
+    },
+  },
 });
 
-module.exports = mongoose.model('User', userSchema);
+module.exports = User;


### PR DESCRIPTION
## Summary
- define Sequelize User model
- implement registration, login and user info retrieval with Sequelize
- add role-based auth middlewares and JWT verification
- sync models when starting the server

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685193a2c0088330a2fbeeec4b5d8168