### PR TITLE
Add publicaciones carousel

### DIFF
--- a/frontend/src/components/PublicacionCard.jsx
+++ b/frontend/src/components/PublicacionCard.jsx
@@ -1,0 +1,27 @@
+export default function PublicacionCard({ pub }) {
+  return (
+    <div className="bg-white shadow hover:shadow-md transition-shadow rounded w-48 shrink-0 overflow-hidden">
+      {pub.portada ? (
+        <img src={pub.portada} alt={pub.titulo} className="h-48 w-full object-cover" />
+      ) : (
+        <div className="h-48 w-full flex items-center justify-center bg-gray-100 text-gray-500">
+          Sin imagen
+        </div>
+      )}
+      <div className="p-2 space-y-1">
+        <h3 className="font-semibold text-sm truncate">{pub.titulo}</h3>
+        <p className="text-xs text-gray-600">
+          {pub.año} - {pub.revista}
+        </p>
+        <a
+          href={pub.doi}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-block text-blue-500 text-sm hover:underline"
+        >
+          Ver DOI
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/data/publicaciones.js
+++ b/frontend/src/data/publicaciones.js
@@ -1,0 +1,26 @@
+export default [
+  {
+    id: 1,
+    titulo: 'Aprendizaje y tecnología',
+    año: 2023,
+    revista: 'Revista Científica',
+    doi: 'https://doi.org/xxxx1',
+    portada: 'https://via.placeholder.com/150',
+  },
+  {
+    id: 2,
+    titulo: 'Innovación educativa',
+    año: 2022,
+    revista: 'Journal of Education',
+    doi: 'https://doi.org/xxxx2',
+    portada: 'https://via.placeholder.com/150',
+  },
+  {
+    id: 3,
+    titulo: 'Metodologías activas de aprendizaje',
+    año: 2021,
+    revista: 'Investigación Pedagógica',
+    doi: 'https://doi.org/xxxx3',
+    portada: 'https://via.placeholder.com/150',
+  },
+];

--- a/frontend/src/pages/Publicaciones.jsx
+++ b/frontend/src/pages/Publicaciones.jsx
@@ -1,14 +1,35 @@
+import { useEffect, useState } from 'react';
+import api from '../services/api';
+import PublicacionCard from '../components/PublicacionCard';
+import fakeData from '../data/publicaciones';
+
 export default function Publicaciones() {
-  const dummy = Array.from({ length: 8 });
+  const [publicaciones, setPublicaciones] = useState([]);
+
+  useEffect(() => {
+    api
+      .get('/publicaciones')
+      .then((res) => setPublicaciones(res.data))
+      .catch(() => setPublicaciones(fakeData));
+  }, []);
+
+  if (publicaciones.length === 0) {
+    return (
+      <section className="p-4">
+        <h1 className="text-2xl font-bold mb-4">Publicaciones</h1>
+        <p>No hay publicaciones disponibles todavía.</p>
+      </section>
+    );
+  }
+
   return (
     <section className="p-4">
       <h1 className="text-2xl font-bold mb-4">Publicaciones</h1>
-      <div className="flex gap-4 overflow-x-auto pb-2">
-        {dummy.map((_, idx) => (
-          <div
-            key={idx}
-            className="min-w-[150px] bg-gray-200 h-32 rounded shrink-0"
-          ></div>
+      <div className="flex gap-4 overflow-x-auto pb-2 scroll-smooth snap-x snap-mandatory">
+        {publicaciones.map((pub) => (
+          <div key={pub.id} className="snap-start">
+            <PublicacionCard pub={pub} />
+          </div>
         ))}
       </div>
     </section>


### PR DESCRIPTION
## Summary
- add `PublicacionCard` component
- load publications via API or fallback data
- show publications in responsive horizontal carousel
- provide example publications data

## Testing
- `npm test` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_6851d4d46c2c8330a69154899d879908