### PR TITLE
Add publications CMS

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -9,6 +9,7 @@ import Proyectos from './pages/Proyectos';
 import Galeria from './pages/Galeria';
 import Contacto from './pages/Contacto';
 import Login from './pages/Login';
+import CMSPublicaciones from './pages/CMSPublicaciones';
 
 export default function App() {
   return (
@@ -20,8 +21,11 @@ export default function App() {
           <Route path="sobre-mi" element={<SobreMi />} />
           <Route path="cv" element={<CV />} />
           <Route path="publicaciones" element={<Publicaciones />} />
-          <Route element={<PrivateRoute />}> 
+          <Route element={<PrivateRoute />}>
             <Route path="proyectos" element={<Proyectos />} />
+          </Route>
+          <Route element={<PrivateRoute roles={['admin','editor']} />}>
+            <Route path="cms-publicaciones" element={<CMSPublicaciones />} />
           </Route>
           <Route path="galeria" element={<Galeria />} />
           <Route path="contacto" element={<Contacto />} />

--- a/frontend/src/components/FormularioPublicacion.jsx
+++ b/frontend/src/components/FormularioPublicacion.jsx
@@ -1,0 +1,81 @@
+import { useState } from 'react';
+
+export default function FormularioPublicacion({ initialData = {}, onSave, onClose }) {
+  const [titulo, setTitulo] = useState(initialData.titulo || '');
+  const [año, setAño] = useState(initialData.año || '');
+  const [revista, setRevista] = useState(initialData.revista || '');
+  const [doi, setDoi] = useState(initialData.doi || '');
+  const [portada, setPortada] = useState(initialData.portada || '');
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (!titulo || !año || !revista || !doi || !portada) {
+      alert('Todos los campos son obligatorios');
+      return;
+    }
+    onSave({ titulo, año, revista, doi, portada });
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
+      <form onSubmit={handleSubmit} className="bg-white p-4 rounded w-80 space-y-2">
+        <h2 className="text-lg font-bold mb-2">
+          {initialData.id ? 'Editar publicación' : 'Nueva publicación'}
+        </h2>
+        <div>
+          <label className="block text-sm">Título</label>
+          <input
+            className="border w-full px-2 py-1"
+            value={titulo}
+            onChange={(e) => setTitulo(e.target.value)}
+          />
+        </div>
+        <div>
+          <label className="block text-sm">Año</label>
+          <input
+            type="number"
+            className="border w-full px-2 py-1"
+            value={año}
+            onChange={(e) => setAño(e.target.value)}
+          />
+        </div>
+        <div>
+          <label className="block text-sm">Revista</label>
+          <input
+            className="border w-full px-2 py-1"
+            value={revista}
+            onChange={(e) => setRevista(e.target.value)}
+          />
+        </div>
+        <div>
+          <label className="block text-sm">DOI</label>
+          <input
+            className="border w-full px-2 py-1"
+            value={doi}
+            onChange={(e) => setDoi(e.target.value)}
+          />
+        </div>
+        <div>
+          <label className="block text-sm">Portada (URL)</label>
+          <input
+            className="border w-full px-2 py-1"
+            value={portada}
+            onChange={(e) => setPortada(e.target.value)}
+          />
+        </div>
+        <div className="flex justify-end gap-2 pt-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-3 py-1 border rounded"
+          >
+            Cancelar
+          </button>
+          <button type="submit" className="px-3 py-1 bg-blue-500 text-white rounded">
+            Guardar
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,6 +1,8 @@
 import { NavLink } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
 
 export default function Navbar() {
+  const { user } = useAuth();
   const linkClass = ({ isActive }) =>
     `px-3 py-2 rounded hover:bg-gray-100 ${isActive ? 'bg-gray-200 font-semibold' : ''}`;
 
@@ -22,6 +24,11 @@ export default function Navbar() {
         <NavLink to="/proyectos" className={linkClass}>
           Proyectos
         </NavLink>
+        {user && (user.role === 'admin' || user.role === 'editor') && (
+          <NavLink to="/cms-publicaciones" className={linkClass}>
+            CMS
+          </NavLink>
+        )}
         <NavLink to="/galeria" className={linkClass}>
           Galería
         </NavLink>

--- a/frontend/src/components/PrivateRoute.jsx
+++ b/frontend/src/components/PrivateRoute.jsx
@@ -1,7 +1,14 @@
 import { Navigate, Outlet } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 
-export default function PrivateRoute() {
-  const { token } = useAuth();
-  return token ? <Outlet /> : <Navigate to="/login" replace />;
+export default function PrivateRoute({ roles }) {
+  const { token, user } = useAuth();
+
+  if (!token) return <Navigate to="/login" replace />;
+
+  if (roles && user && !roles.includes(user.role)) {
+    return <Navigate to="/" replace />;
+  }
+
+  return <Outlet />;
 }

--- a/frontend/src/pages/CMSPublicaciones.jsx
+++ b/frontend/src/pages/CMSPublicaciones.jsx
@@ -1,0 +1,95 @@
+import { useEffect, useState } from 'react';
+import api from '../services/api';
+import FormularioPublicacion from '../components/FormularioPublicacion';
+import fakeData from '../data/publicaciones';
+
+export default function CMSPublicaciones() {
+  const [publicaciones, setPublicaciones] = useState([]);
+  const [showForm, setShowForm] = useState(false);
+  const [editPub, setEditPub] = useState(null);
+
+  const load = () => {
+    api
+      .get('/publicaciones')
+      .then((res) => setPublicaciones(res.data))
+      .catch(() => setPublicaciones(fakeData));
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const handleCreate = () => {
+    setEditPub(null);
+    setShowForm(true);
+  };
+
+  const handleEdit = (pub) => {
+    setEditPub(pub);
+    setShowForm(true);
+  };
+
+  const handleSave = async (data) => {
+    try {
+      if (editPub) {
+        const res = await api.put(`/publicaciones/${editPub.id}`, data);
+        setPublicaciones((p) => p.map((it) => (it.id === editPub.id ? res.data : it)));
+      } else {
+        const res = await api.post('/publicaciones', data);
+        setPublicaciones((p) => [...p, res.data]);
+      }
+      setShowForm(false);
+    } catch (err) {
+      console.error(err);
+      alert('Error al guardar');
+    }
+  };
+
+  const handleDelete = async (id) => {
+    if (!confirm('¿Eliminar publicación?')) return;
+    try {
+      await api.delete(`/publicaciones/${id}`);
+      setPublicaciones((p) => p.filter((it) => it.id !== id));
+    } catch (err) {
+      console.error(err);
+      alert('Error al eliminar');
+    }
+  };
+
+  return (
+    <section className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">CMS Publicaciones</h1>
+      <button onClick={handleCreate} className="px-3 py-1 bg-blue-500 text-white rounded">
+        Nueva publicación
+      </button>
+      <ul className="space-y-2">
+        {publicaciones.map((pub) => (
+          <li key={pub.id} className="border p-2 flex justify-between items-center">
+            <span>{pub.titulo}</span>
+            <div className="space-x-2">
+              <button
+                onClick={() => handleEdit(pub)}
+                className="px-2 py-1 text-sm bg-yellow-500 text-white rounded"
+              >
+                Editar
+              </button>
+              <button
+                onClick={() => handleDelete(pub.id)}
+                className="px-2 py-1 text-sm bg-red-500 text-white rounded"
+              >
+                Eliminar
+              </button>
+            </div>
+          </li>
+        ))}
+      </ul>
+      {showForm && (
+        <FormularioPublicacion
+          initialData={editPub || {}}
+          onSave={handleSave}
+          onClose={() => setShowForm(false)}
+        />
+      )}
+    </section>
+  );
+}

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -4,4 +4,9 @@ const api = axios.create({
   baseURL: 'http://localhost:3000/api',
 });
 
+const token = localStorage.getItem('token');
+if (token) {
+  api.defaults.headers.common['Authorization'] = `Bearer ${token}`;
+}
+
 export default api;


### PR DESCRIPTION
## Summary
- add JWT header configuration in axios instance
- enable role-based PrivateRoute
- add CMS page and form to manage publications
- show CMS link in navbar for admin/editor
- create route for CMS

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6851d6daffa48330b53564ecd80771cd