### PR TITLE
Configure API URL via env variable

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:3000/api

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const api = axios.create({
-  baseURL: 'http://localhost:3000/api',
+  baseURL: import.meta.env.VITE_API_URL,
 });
 
 const token = localStorage.getItem('token');


### PR DESCRIPTION
## Summary
- create a `.env` file for frontend
- use `import.meta.env.VITE_API_URL` in Axios API service

No changes were required to `vite.config.js` because Vite automatically loads `.env` files.

## Testing
- `npm test` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_6852245112cc83308632f54791ed3d13