### PR TITLE
Add image upload capability

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -6,6 +6,8 @@ const dotenv = require('dotenv');
 const sequelize = require('./config/db'); // <-- nuevo import
 const authRoutes = require('./routes/authRoutes');
 const publicacionesRoutes = require('./routes/publicacionesRoutes');
+const uploadRoutes = require('./routes/uploadRoutes');
+const path = require('path');
 
 dotenv.config();
 
@@ -14,8 +16,10 @@ const PORT = process.env.PORT || 3000;
 
 app.use(cors());
 app.use(express.json());
+app.use('/uploads', express.static(path.join(__dirname, 'public/uploads')));
 app.use('/api', publicacionesRoutes);
 app.use('/api', authRoutes);
+app.use('/api', uploadRoutes);
 
 // Conectar DB y arrancar servidor
 sequelize.authenticate()

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -16,7 +16,8 @@
         "jsonwebtoken": "^9.0.0",
         "mongoose": "^7.3.1",
         "sequelize": "^6.37.7",
-        "sqlite3": "^5.1.7"
+        "sqlite3": "^5.1.7",
+        "multer": "^1.4.5"
       },
       "devDependencies": {
         "nodemon": "^2.0.22"

--- a/backend/package.json
+++ b/backend/package.json
@@ -17,7 +17,8 @@
     "jsonwebtoken": "^9.0.0",
     "mongoose": "^7.3.1",
     "sequelize": "^6.37.7",
-    "sqlite3": "^5.1.7"
+    "sqlite3": "^5.1.7",
+    "multer": "^1.4.5"
   },
   "devDependencies": {
     "nodemon": "^2.0.22"

--- a/backend/routes/uploadRoutes.js
+++ b/backend/routes/uploadRoutes.js
@@ -1,0 +1,26 @@
+const express = require('express');
+const multer = require('multer');
+const path = require('path');
+
+const router = express.Router();
+
+const storage = multer.diskStorage({
+  destination: (req, file, cb) => {
+    cb(null, path.join(__dirname, '../public/uploads'));
+  },
+  filename: (req, file, cb) => {
+    const ext = path.extname(file.originalname);
+    const unique = Date.now() + '-' + Math.round(Math.random() * 1e9) + ext;
+    cb(null, unique);
+  }
+});
+
+const upload = multer({ storage });
+
+router.post('/upload', upload.single('image'), (req, res) => {
+  const filePath = `/uploads/${req.file.filename}`;
+  const url = `${req.protocol}://${req.get('host')}${filePath}`;
+  res.json({ url });
+});
+
+module.exports = router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -1,8 +1,11 @@
 const express = require('express');
 const mongoose = require('mongoose');
+const path = require('path');
+const uploadRoutes = require('../routes/uploadRoutes');
 
 const app = express();
 app.use(express.json());
+app.use('/uploads', express.static(path.join(__dirname, '../public/uploads')));
 
 const mongoUri = process.env.MONGO_URI || 'mongodb://localhost:27017/portfolio';
 mongoose.connect(mongoUri, {
@@ -16,6 +19,7 @@ app.get('/api', (req, res) => {
 });
 
 app.use('/api', require('../routes/authRoutes'));
+app.use('/api', uploadRoutes);
 app.use('/api/sections', require('./routes/sections'));
 
 const PORT = process.env.PORT || 3001;

--- a/frontend/src/components/FormularioPublicacion.jsx
+++ b/frontend/src/components/FormularioPublicacion.jsx
@@ -11,6 +11,7 @@ const FormularioPublicacion = ({ publicacion, onClose, onRefresh }) => {
     doi: '',
     portada: ''
   });
+  const [file, setFile] = useState(null);
 
   useEffect(() => {
     if (publicacion) {
@@ -21,6 +22,7 @@ const FormularioPublicacion = ({ publicacion, onClose, onRefresh }) => {
         doi: publicacion.doi || '',
         portada: publicacion.portada || ''
       });
+      setFile(null);
     }
   }, [publicacion]);
 
@@ -29,13 +31,27 @@ const FormularioPublicacion = ({ publicacion, onClose, onRefresh }) => {
     setForm((prev) => ({ ...prev, [name]: value }));
   };
 
+  const handleFileChange = (e) => {
+    setFile(e.target.files[0]);
+  };
+
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
+      let data = { ...form };
+      if (file) {
+        const fd = new FormData();
+        fd.append('image', file);
+        const res = await api.post('/upload', fd, {
+          headers: { 'Content-Type': 'multipart/form-data' }
+        });
+        data.portada = res.data.url;
+      }
+
       if (publicacion?.id) {
-        await api.put(`/publicaciones/${publicacion.id}`, form);
+        await api.put(`/publicaciones/${publicacion.id}`, data);
       } else {
-        await api.post('/publicaciones', form);
+        await api.post('/publicaciones', data);
       }
       onRefresh();
       onClose();
@@ -79,6 +95,11 @@ const FormularioPublicacion = ({ publicacion, onClose, onRefresh }) => {
         onChange={handleChange}
         className="w-full border px-3 py-2 rounded"
         required
+      />
+      <input
+        type="file"
+        onChange={handleFileChange}
+        className="w-full border px-3 py-2 rounded"
       />
       <input
         name="portada"


### PR DESCRIPTION
## Summary
- install `multer` dependency
- create `/upload` route to store images
- expose uploaded files via `/uploads`
- enable file uploads in the publications form

## Testing
- `npm test` (backend)
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68522462e4588330ac53bd6403328c6d