### PR TITLE
Add publication model and routes

### DIFF
--- a/backend/controllers/publicacionController.js
+++ b/backend/controllers/publicacionController.js
@@ -1,0 +1,48 @@
+const Publicacion = require('../models/Publicacion');
+
+const list = async (req, res) => {
+  try {
+    const publicaciones = await Publicacion.findAll();
+    res.json(publicaciones);
+  } catch (err) {
+    res.status(500).json({ message: 'Error al obtener publicaciones' });
+  }
+};
+
+const create = async (req, res) => {
+  try {
+    const nueva = await Publicacion.create(req.body);
+    res.status(201).json(nueva);
+  } catch (err) {
+    res.status(400).json({ message: 'Error al crear publicaci\u00f3n' });
+  }
+};
+
+const update = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const [rows] = await Publicacion.update(req.body, { where: { id } });
+    if (rows === 0) {
+      return res.status(404).json({ message: 'Publicaci\u00f3n no encontrada' });
+    }
+    const actualizada = await Publicacion.findByPk(id);
+    res.json(actualizada);
+  } catch (err) {
+    res.status(400).json({ message: 'Error al actualizar publicaci\u00f3n' });
+  }
+};
+
+const remove = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const rows = await Publicacion.destroy({ where: { id } });
+    if (rows === 0) {
+      return res.status(404).json({ message: 'Publicaci\u00f3n no encontrada' });
+    }
+    res.json({ message: 'Publicaci\u00f3n eliminada' });
+  } catch (err) {
+    res.status(400).json({ message: 'Error al eliminar publicaci\u00f3n' });
+  }
+};
+
+module.exports = { create, update, remove, list };

--- a/backend/index.js
+++ b/backend/index.js
@@ -5,7 +5,7 @@ const cors = require('cors');
 const dotenv = require('dotenv');
 const sequelize = require('./config/db'); // <-- nuevo import
 const authRoutes = require('./routes/authRoutes');
-const publicacionesRoutes = require('./routes/publicacionesRoutes');
+const publicacionRoutes = require('./routes/publicacionRoutes');
 
 dotenv.config();
 
@@ -14,7 +14,7 @@ const PORT = process.env.PORT || 3000;
 
 app.use(cors());
 app.use(express.json());
-app.use('/api', publicacionesRoutes);
+app.use('/api/publicaciones', publicacionRoutes);
 app.use('/api', authRoutes);
 
 // Conectar DB y arrancar servidor

--- a/backend/middleware/authMiddleware.js
+++ b/backend/middleware/authMiddleware.js
@@ -39,7 +39,7 @@ const isAdminOrEditor = (req, res, next) => {
   if (req.userRole === 'admin' || req.userRole === 'editor') {
     next();
   } else {
-    return res.status(403).json({ message: 'Acceso denegado' });
+    return res.status(403).json({ message: 'Acceso solo para administradores o editores' });
   }
 };
 

--- a/backend/models/Publicacion.js
+++ b/backend/models/Publicacion.js
@@ -1,0 +1,27 @@
+const { DataTypes } = require('sequelize');
+const sequelize = require('../config/db');
+
+const Publicacion = sequelize.define('Publicacion', {
+  titulo: {
+    type: DataTypes.STRING,
+    allowNull: false
+  },
+  anio: {
+    type: DataTypes.INTEGER,
+    allowNull: false
+  },
+  revista: {
+    type: DataTypes.STRING,
+    allowNull: false
+  },
+  doi: {
+    type: DataTypes.STRING,
+    allowNull: false
+  },
+  portada: {
+    type: DataTypes.STRING,
+    allowNull: true
+  }
+});
+
+module.exports = Publicacion;

--- a/backend/routes/publicacionRoutes.js
+++ b/backend/routes/publicacionRoutes.js
@@ -1,0 +1,12 @@
+const express = require('express');
+const { verifyToken, isAdminOrEditor } = require('../middleware/authMiddleware');
+const { create, update, remove, list } = require('../controllers/publicacionController');
+
+const router = express.Router();
+
+router.get('/', verifyToken, isAdminOrEditor, list);
+router.post('/', verifyToken, isAdminOrEditor, create);
+router.put('/:id', verifyToken, isAdminOrEditor, update);
+router.delete('/:id', verifyToken, isAdminOrEditor, remove);
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- model for publications
- controllers for CRUD on publications
- API routes for `/api/publicaciones`
- mount the routes and tweak auth middleware

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685224deeb208330a5dcacbd4df8e7c9