### PR TITLE
Fix auth routing and server middleware

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -18,7 +18,9 @@ dotenv.config();
 const app = express();
 const PORT = process.env.PORT || 3000;
 
+// Middlewares
 app.use(cors());
+// Habilita lectura de JSON en los cuerpos de las peticiones
 app.use(express.json());
 app.use('/uploads', express.static(path.join(__dirname, 'public/uploads')));
 app.use('/', publicRoutes);

--- a/backend/routes/authRoutes.js
+++ b/backend/routes/authRoutes.js
@@ -1,16 +1,16 @@
 const express = require('express');
 const { register, login, getMe } = require('../controllers/authController');
-const { verifyToken, isAdmin } = require('../middleware/authMiddleware');
+const { verifyToken } = require('../middleware/authMiddleware');
 
 const router = express.Router();
 
-router.post('/register', register);
+// Ruta para iniciar sesión
 router.post('/login', login);
-router.get('/me', verifyToken, getMe);
 
-// Ejemplo ruta para admin:
-router.post('/admin/crear-usuario', verifyToken, isAdmin, (req, res) => {
-  // lógica aquí
-});
+// Ruta para registrar usuarios
+router.post('/register', register);
+
+// Información del usuario autenticado
+router.get('/me', verifyToken, getMe);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- streamline auth routes to expose login, register and me endpoints
- document express.json middleware in server setup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852324e585083308f143415a892e569