### PR TITLE
Fix API base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,13 @@ Las siguientes variables se leen desde el archivo `.env` en el directorio `backe
 
 ### Frontend
 
-La aplicación frontend no requiere variables de entorno adicionales por defecto.
+El archivo `frontend/.env` define la variable `VITE_API_URL`, que indica la URL
+base para las peticiones al API. Por defecto debe apuntar al backend en
+desarrollo:
+
+```env
+VITE_API_URL=http://localhost:3000/api
+```
 
 ## Ejecución en modo desarrollo
 

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,1 +1,1 @@
-VITE_API_URL=http://localhost:3000
+VITE_API_URL=http://localhost:3000/api


### PR DESCRIPTION
## Summary
- update README with VITE_API_URL instructions
- set frontend `.env` to use `/api` base URL

## Testing
- `npm test`
- `npm run build` *(fails: vite Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_685233d4100c8330b1f6d420ab2cac46