### PR TITLE
Improve backend env config

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -1,2 +1,7 @@
 PORT=3000
-JWT_SECRET=miClaveSuperSecreta
+NODE_ENV=development
+JWT_SECRET=Vbs?VZb-.0\8ClXH^Z3z?:L@>/_QF\8HCKfUqE|fzl[C.$=P;9a0k|}H[z'//>{M
+# Debe ser único en producción
+DB_FILE=./database.sqlite
+FRONTEND_URL=http://localhost:5173
+BCRYPT_ROUNDS=12

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,3 +1,17 @@
+# Port where the API server runs
 PORT=3000
-JWT_SECRET=devsecret
+
+# Current Node environment
+NODE_ENV=development
+
+# Secret used to sign JWT tokens (minimum 64 characters)
+JWT_SECRET=your_super_secure_jwt_secret_here_min_64_chars
+
+# Path to the SQLite database file
 DB_FILE=./database.sqlite
+
+# Allowed frontend origin for CORS
+FRONTEND_URL=http://localhost:5173
+
+# Bcrypt hashing rounds
+BCRYPT_ROUNDS=12

--- a/backend/config/db.js
+++ b/backend/config/db.js
@@ -6,7 +6,7 @@ const { Sequelize } = require('sequelize');
 const sequelize = new Sequelize({
   dialect: 'sqlite',
   storage: process.env.DB_FILE || './database.sqlite',
-  logging: false // opcional: elimina mensajes en consola
+  logging: process.env.NODE_ENV === 'development' ? console.log : false // opcional: elimina mensajes en consola
 });
 
 module.exports = sequelize;

--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -15,7 +15,8 @@ const register = async (req, res) => {
       return res.status(400).json({ message: 'El correo ya está registrado' });
     }
 
-    const hashedPassword = await bcrypt.hash(password, 10);
+    const rounds = parseInt(process.env.BCRYPT_ROUNDS, 10) || 10;
+    const hashedPassword = await bcrypt.hash(password, rounds);
 
     await User.create({
       name,

--- a/backend/index.js
+++ b/backend/index.js
@@ -3,7 +3,7 @@
 const express = require('express');
 const cors = require('cors');
 const dotenv = require('dotenv');
-const sequelize = require('./config/db'); // <-- nuevo import
+const sequelize = require('./config/db');
 require('./models/User');
 require('./models/Publicacion');
 const authRoutes = require('./routes/authRoutes');
@@ -17,9 +17,12 @@ dotenv.config();
 
 const app = express();
 const PORT = process.env.PORT || 3000;
+const corsOptions = {
+  origin: process.env.FRONTEND_URL || 'http://localhost:5173'
+};
 
 // Middlewares
-app.use(cors());
+app.use(cors(corsOptions));
 // Habilita lectura de JSON en los cuerpos de las peticiones
 app.use(express.json());
 app.use('/uploads', express.static(path.join(__dirname, 'public/uploads')));


### PR DESCRIPTION
## Summary
- regenerate JWT secret
- add NODE_ENV, FRONTEND_URL and BCRYPT_ROUNDS to env files
- update example environment variables with comments
- use FRONTEND_URL in CORS configuration
- make bcrypt rounds configurable
- show DB logging only in development

## Testing
- `NODE_ENV=development FRONTEND_URL=http://localhost:5173 BCRYPT_ROUNDS=12 JWT_SECRET=test DB_FILE=./database.sqlite PORT=3000 node backend/index.js >/tmp/server.log 2>&1 &` *(fails: invalid ELF header)*

------
https://chatgpt.com/codex/tasks/task_e_685238bc8fdc8330a7ee892752fc6a60