### PR TITLE
Fix publicaciones API routes

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -73,9 +73,12 @@ app.use('/api', speedLimiter);
 // Middleware existente
 app.use(express.json());
 app.use('/uploads', express.static(path.join(__dirname, 'public/uploads')));
+// Rutas públicas (sin /api prefix)
 app.use('/', publicRoutes);
-app.use('/api', publicacionesRoutes);
+
+// Rutas protegidas (con /api prefix)
 app.use('/api', authRoutes);
+app.use('/api', publicacionesRoutes);
 app.use('/api', uploadRoutes);
 
 app.use(errorHandler);

--- a/backend/routes/publicacionesRoutes.js
+++ b/backend/routes/publicacionesRoutes.js
@@ -7,10 +7,10 @@ const { verifyToken, isAdminOrEditor } = require('../middleware/authMiddleware')
 const { getPublicaciones, crearPublicacion, actualizarPublicacion, eliminarPublicacion } = require('../controllers/publicacionesController');
 
 const validatePublicacion = [
-  body('titulo').notEmpty(),
-  body('año').isInt(),
-  body('revista').notEmpty(),
-  body('doi').notEmpty(),
+  body('titulo').notEmpty().trim().escape(),
+  body('año').isInt({ min: 1900, max: new Date().getFullYear() + 1 }),
+  body('revista').notEmpty().trim().escape(),
+  body('doi').notEmpty().trim(),
   (req, res, next) => {
     const errors = validationResult(req);
     if (!errors.isEmpty()) {

--- a/frontend/src/hooks/usePublicaciones.js
+++ b/frontend/src/hooks/usePublicaciones.js
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import api from '../services/api';
+import axios from 'axios';
 
 export default function usePublicaciones() {
   const [publicaciones, setPublicaciones] = useState([]);
@@ -9,34 +10,62 @@ export default function usePublicaciones() {
   const load = async () => {
     setLoading(true);
     try {
-      const res = await api.get('/publicaciones');
+      // Usar ruta pública sin autenticación para cargar datos
+      const baseURL = import.meta.env.VITE_API_URL.replace('/api', '');
+      const res = await axios.get(`${baseURL}/publicaciones`);
       setPublicaciones(res.data);
       setError(null);
     } catch (err) {
       setError(err);
+      console.error('Error cargando publicaciones:', err);
     } finally {
       setLoading(false);
     }
   };
 
   const create = async (data) => {
-    const res = await api.post('/api/publicaciones', data);
-    setPublicaciones((p) => [...p, res.data]);
+    try {
+      const res = await api.post('/publicaciones', data);
+      setPublicaciones((p) => [...p, res.data]);
+      return res.data;
+    } catch (err) {
+      console.error('Error creando publicación:', err);
+      throw err;
+    }
   };
 
   const update = async (id, data) => {
-    const res = await api.put(`/api/publicaciones/${id}`, data);
-    setPublicaciones((p) => p.map((it) => (it.id === id ? res.data : it)));
+    try {
+      const res = await api.put(`/publicaciones/${id}`, data);
+      setPublicaciones((p) => p.map((it) => (it.id === id ? res.data : it)));
+      return res.data;
+    } catch (err) {
+      console.error('Error actualizando publicación:', err);
+      throw err;
+    }
   };
 
   const remove = async (id) => {
-    await api.delete(`/api/publicaciones/${id}`);
-    setPublicaciones((p) => p.filter((it) => it.id !== id));
+    try {
+      await api.delete(`/publicaciones/${id}`);
+      setPublicaciones((p) => p.filter((it) => it.id !== id));
+    } catch (err) {
+      console.error('Error eliminando publicación:', err);
+      throw err;
+    }
   };
 
   useEffect(() => {
     load();
   }, []);
 
-  return { publicaciones, loading, error, load, create, update, remove };
+  return {
+    publicaciones,
+    loading,
+    error,
+    load,
+    create,
+    update,
+    remove,
+  };
 }


### PR DESCRIPTION
## Summary
- clean up mounting of public and private routes in backend
- validate publicaciones data more strictly
- rework usePublicaciones hook for consistent public/private API routes

## Testing
- `npm test` *(fails: Missing script)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68523add8ea88330a6fc73d409fd3a03