### PR TITLE
Improve backend validation and security

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -1,31 +1,51 @@
 const bcrypt = require('bcrypt');
 const jwt = require('jsonwebtoken');
+const { validationResult } = require('express-validator');
 const User = require('../models/User');
 
 const register = async (req, res) => {
   try {
-    const { name, email, password, role } = req.body;
-
-    if (!name || !email || !password) {
-      return res.status(400).json({ message: 'Todos los campos son obligatorios' });
+    // Verificar errores de validación
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({
+        message: 'Datos inválidos',
+        errors: errors.array()
+      });
     }
 
-    const existingUser = await User.findOne({ where: { email } });
+    const { name, email, password, role } = req.body;
+
+    // Verificar si el usuario ya existe
+    const existingUser = await User.findOne({ where: { email: email.toLowerCase() } });
     if (existingUser) {
       return res.status(400).json({ message: 'El correo ya está registrado' });
     }
 
-    const rounds = parseInt(process.env.BCRYPT_ROUNDS, 10) || 10;
-    const hashedPassword = await bcrypt.hash(password, rounds);
+    // Hashear contraseña con rounds configurables
+    const saltRounds = parseInt(process.env.BCRYPT_ROUNDS) || 12;
+    const hashedPassword = await bcrypt.hash(password, saltRounds);
 
-    await User.create({
-      name,
-      email,
+    // Crear usuario
+    const newUser = await User.create({
+      name: name.trim(),
+      email: email.toLowerCase(),
       password: hashedPassword,
       role: role || 'editor'
     });
 
-    res.status(201).json({ message: 'Usuario registrado exitosamente' });
+    // No devolver la contraseña
+    const userResponse = {
+      id: newUser.id,
+      name: newUser.name,
+      email: newUser.email,
+      role: newUser.role
+    };
+
+    res.status(201).json({
+      message: 'Usuario registrado exitosamente',
+      user: userResponse
+    });
   } catch (error) {
     console.error('Error en registro:', error);
     res.status(500).json({ message: 'Error interno del servidor' });
@@ -34,29 +54,54 @@ const register = async (req, res) => {
 
 const login = async (req, res) => {
   try {
+    // Verificar errores de validación
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({
+        message: 'Datos inválidos',
+        errors: errors.array()
+      });
+    }
+
     const { email, password } = req.body;
 
-    if (!email || !password) {
-      return res.status(400).json({ message: 'Correo y contraseña son requeridos' });
-    }
-
-    const user = await User.findOne({ where: { email } });
+    // Buscar usuario (case insensitive)
+    const user = await User.findOne({ where: { email: email.toLowerCase() } });
     if (!user) {
-      return res.status(404).json({ message: 'Usuario no encontrado' });
+      return res.status(401).json({ message: 'Credenciales inválidas' });
     }
 
+    // Verificar contraseña
     const isMatch = await bcrypt.compare(password, user.password);
     if (!isMatch) {
-      return res.status(401).json({ message: 'Contraseña incorrecta' });
+      return res.status(401).json({ message: 'Credenciales inválidas' });
     }
 
+    // Generar JWT
     const token = jwt.sign(
-      { id: user.id, role: user.role },
+      {
+        id: user.id,
+        role: user.role,
+        email: user.email
+      },
       process.env.JWT_SECRET,
-      { expiresIn: '1d' }
+      {
+        expiresIn: '24h',
+        issuer: 'portfolio-cms',
+        audience: 'portfolio-frontend'
+      }
     );
 
-    res.status(200).json({ token });
+    // Respuesta exitosa
+    res.status(200).json({
+      token,
+      user: {
+        id: user.id,
+        name: user.name,
+        email: user.email,
+        role: user.role
+      }
+    });
   } catch (error) {
     console.error('Error en login:', error);
     res.status(500).json({ message: 'Error interno del servidor' });
@@ -66,7 +111,7 @@ const login = async (req, res) => {
 const getMe = async (req, res) => {
   try {
     const user = await User.findByPk(req.userId, {
-      attributes: ['id', 'name', 'email', 'role']
+      attributes: ['id', 'name', 'email', 'role', 'createdAt']
     });
 
     if (!user) {

--- a/backend/controllers/publicacionesController.js
+++ b/backend/controllers/publicacionesController.js
@@ -1,43 +1,153 @@
-// backend/controllers/publicacionesController.js
-
+const { validationResult } = require('express-validator');
+const { Op } = require('sequelize');
 const Publicacion = require('../models/Publicacion');
 
-// Controladores CRUD
+// Obtener todas las publicaciones
 const getPublicaciones = async (req, res) => {
   try {
-    const publicaciones = await Publicacion.findAll();
-    res.json(publicaciones);
+    const { page = 1, limit = 50, search } = req.query;
+    const offset = (page - 1) * limit;
+
+    let whereClause = {};
+    if (search) {
+      whereClause = {
+        [Op.or]: [
+          { titulo: { [Op.like]: `%${search}%` } },
+          { revista: { [Op.like]: `%${search}%` } }
+        ]
+      };
+    }
+
+    const { count, rows } = await Publicacion.findAndCountAll({
+      where: whereClause,
+      limit: parseInt(limit),
+      offset: parseInt(offset),
+      order: [['año', 'DESC'], ['createdAt', 'DESC']]
+    });
+
+    res.json({
+      publicaciones: rows,
+      totalCount: count,
+      currentPage: parseInt(page),
+      totalPages: Math.ceil(count / limit)
+    });
   } catch (err) {
+    console.error('Error al obtener publicaciones:', err);
     res.status(500).json({ message: 'Error al obtener publicaciones' });
   }
 };
 
+// Crear nueva publicación
 const crearPublicacion = async (req, res) => {
   try {
-    const nueva = await Publicacion.create(req.body);
-    res.status(201).json(nueva);
+    // Verificar errores de validación
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({
+        message: 'Datos inválidos',
+        errors: errors.array()
+      });
+    }
+
+    const { titulo, año, revista, doi, portada } = req.body;
+
+    // Verificar si ya existe una publicación con el mismo DOI
+    const existingPub = await Publicacion.findOne({ where: { doi } });
+    if (existingPub) {
+      return res.status(400).json({
+        message: 'Ya existe una publicación con este DOI'
+      });
+    }
+
+    const nueva = await Publicacion.create({
+      titulo: titulo.trim(),
+      año: parseInt(año),
+      revista: revista.trim(),
+      doi: doi.trim(),
+      portada: portada ? portada.trim() : null
+    });
+
+    res.status(201).json({
+      message: 'Publicación creada exitosamente',
+      publicacion: nueva
+    });
   } catch (err) {
-    res.status(400).json({ message: 'Error al crear publicación' });
+    console.error('Error al crear publicación:', err);
+    res.status(500).json({ message: 'Error al crear publicación' });
   }
 };
 
+// Actualizar publicación
 const actualizarPublicacion = async (req, res) => {
   try {
-    const id = req.params.id;
-    const actualizada = await Publicacion.update(req.body, { where: { id } });
-    res.json({ message: 'Publicación actualizada' });
+    // Verificar errores de validación
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({
+        message: 'Datos inválidos',
+        errors: errors.array()
+      });
+    }
+
+    const { id } = req.params;
+    const { titulo, año, revista, doi, portada } = req.body;
+
+    // Verificar que la publicación existe
+    const publicacion = await Publicacion.findByPk(id);
+    if (!publicacion) {
+      return res.status(404).json({ message: 'Publicación no encontrada' });
+    }
+
+    // Verificar DOI duplicado (excluyendo la publicación actual)
+    if (doi !== publicacion.doi) {
+      const existingPub = await Publicacion.findOne({
+        where: {
+          doi,
+          id: { [Op.ne]: id }
+        }
+      });
+      if (existingPub) {
+        return res.status(400).json({
+          message: 'Ya existe otra publicación con este DOI'
+        });
+      }
+    }
+
+    // Actualizar
+    await publicacion.update({
+      titulo: titulo.trim(),
+      año: parseInt(año),
+      revista: revista.trim(),
+      doi: doi.trim(),
+      portada: portada ? portada.trim() : null
+    });
+
+    res.json({
+      message: 'Publicación actualizada exitosamente',
+      publicacion
+    });
   } catch (err) {
-    res.status(400).json({ message: 'Error al actualizar publicación' });
+    console.error('Error al actualizar publicación:', err);
+    res.status(500).json({ message: 'Error al actualizar publicación' });
   }
 };
 
+// Eliminar publicación
 const eliminarPublicacion = async (req, res) => {
   try {
-    const id = req.params.id;
-    await Publicacion.destroy({ where: { id } });
-    res.json({ message: 'Publicación eliminada' });
+    const { id } = req.params;
+
+    const publicacion = await Publicacion.findByPk(id);
+    if (!publicacion) {
+      return res.status(404).json({ message: 'Publicación no encontrada' });
+    }
+
+    await publicacion.destroy();
+
+    res.json({ message: 'Publicación eliminada exitosamente' });
   } catch (err) {
-    res.status(400).json({ message: 'Error al eliminar publicación' });
+    console.error('Error al eliminar publicación:', err);
+    res.status(500).json({ message: 'Error al eliminar publicación' });
   }
 };
 

--- a/backend/middleware/authMiddleware.js
+++ b/backend/middleware/authMiddleware.js
@@ -1,46 +1,62 @@
-// backend/middleware/authMiddleware.js
-
 const jwt = require('jsonwebtoken');
 
 const verifyToken = (req, res, next) => {
   const authHeader = req.headers['authorization'];
 
   if (!authHeader || !authHeader.startsWith('Bearer ')) {
-    return res.status(403).json({ message: 'Token no proporcionado' });
+    return res.status(401).json({
+      message: 'Token de acceso requerido'
+    });
   }
 
   const token = authHeader.split(' ')[1];
 
   try {
-    const decoded = jwt.verify(token, process.env.JWT_SECRET);
+    const decoded = jwt.verify(token, process.env.JWT_SECRET, {
+      issuer: 'portfolio-cms',
+      audience: 'portfolio-frontend'
+    });
+
     req.userId = decoded.id;
     req.userRole = decoded.role;
+    req.userEmail = decoded.email;
     next();
   } catch (error) {
-    return res.status(401).json({ message: 'Token inválido o expirado' });
+    if (error.name === 'TokenExpiredError') {
+      return res.status(401).json({ message: 'Token expirado' });
+    } else if (error.name === 'JsonWebTokenError') {
+      return res.status(401).json({ message: 'Token inválido' });
+    } else {
+      return res.status(401).json({ message: 'Error de autenticación' });
+    }
   }
 };
 
 const isAdmin = (req, res, next) => {
   if (req.userRole !== 'admin') {
-    return res.status(403).json({ message: 'Acceso solo para administradores' });
+    return res.status(403).json({
+      message: 'Acceso denegado: Se requieren permisos de administrador'
+    });
   }
   next();
 };
 
 const isEditor = (req, res, next) => {
   if (req.userRole !== 'editor') {
-    return res.status(403).json({ message: 'Acceso solo para editores' });
+    return res.status(403).json({
+      message: 'Acceso denegado: Se requieren permisos de editor'
+    });
   }
   next();
 };
 
 const isAdminOrEditor = (req, res, next) => {
-  if (req.userRole === 'admin' || req.userRole === 'editor') {
-    next();
-  } else {
-    return res.status(403).json({ message: 'Acceso denegado' });
+  if (req.userRole !== 'admin' && req.userRole !== 'editor') {
+    return res.status(403).json({
+      message: 'Acceso denegado: Se requieren permisos de editor o administrador'
+    });
   }
+  next();
 };
 
 module.exports = {

--- a/backend/routes/authRoutes.js
+++ b/backend/routes/authRoutes.js
@@ -1,16 +1,46 @@
 const express = require('express');
+const { body } = require('express-validator');
 const { register, login, getMe } = require('../controllers/authController');
 const { verifyToken } = require('../middleware/authMiddleware');
 
 const router = express.Router();
 
-// Ruta para iniciar sesión
-router.post('/login', login);
+// Validaciones para registro
+const validateRegister = [
+  body('name')
+    .trim()
+    .isLength({ min: 2, max: 50 })
+    .withMessage('El nombre debe tener entre 2 y 50 caracteres')
+    .escape(),
+  body('email')
+    .isEmail()
+    .normalizeEmail()
+    .withMessage('Email inválido'),
+  body('password')
+    .isLength({ min: 8 })
+    .withMessage('La contraseña debe tener al menos 8 caracteres')
+    .matches(/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)/)
+    .withMessage('La contraseña debe contener al menos una mayúscula, una minúscula y un número'),
+  body('role')
+    .optional()
+    .isIn(['admin', 'editor'])
+    .withMessage('Rol inválido')
+];
 
-// Ruta para registrar usuarios
-router.post('/register', register);
+// Validaciones para login
+const validateLogin = [
+  body('email')
+    .isEmail()
+    .normalizeEmail()
+    .withMessage('Email inválido'),
+  body('password')
+    .notEmpty()
+    .withMessage('Contraseña requerida')
+];
 
-// Información del usuario autenticado
+// Rutas
+router.post('/register', validateRegister, register);
+router.post('/login', validateLogin, login);
 router.get('/me', verifyToken, getMe);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- add strict input validation and sanitization for auth endpoints
- enforce duplicate checks and pagination for publications
- verify JWT audience/issuer and add role helpers
- validate registration and login inputs via router

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6852f8ffff6483308477ac48c89cad2a