### PR TITLE
Add loading states, error boundary, and search to publications

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,5 @@
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import ErrorBoundary from './components/ErrorBoundary';
 import Layout from './components/Layout';
 import PrivateRoute from './components/PrivateRoute';
 import Home from './pages/Home';
@@ -13,8 +14,9 @@ import CMSPublicaciones from './pages/CMSPublicaciones';
 
 export default function App() {
   return (
-    <Router>
-      <Routes>
+    <ErrorBoundary>
+      <Router>
+        <Routes>
         <Route path="/login" element={<Login />} />
         <Route path="/" element={<Layout />}>
           <Route index element={<Home />} />
@@ -30,7 +32,8 @@ export default function App() {
           <Route path="galeria" element={<Galeria />} />
           <Route path="contacto" element={<Contacto />} />
         </Route>
-      </Routes>
-    </Router>
+        </Routes>
+      </Router>
+    </ErrorBoundary>
   );
 }

--- a/frontend/src/components/ErrorBoundary.jsx
+++ b/frontend/src/components/ErrorBoundary.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    console.error('Error boundary caught an error:', error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="min-h-screen flex items-center justify-center bg-gray-50">
+          <div className="max-w-md w-full bg-white shadow-lg rounded-lg p-6">
+            <div className="flex items-center">
+              <div className="flex-shrink-0">
+                <svg className="h-8 w-8 text-red-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L3.732 16.5c-.77.833.192 2.5 1.732 2.5z" />
+                </svg>
+              </div>
+              <div className="ml-3">
+                <h3 className="text-sm font-medium text-gray-800">
+                  Algo salió mal
+                </h3>
+                <div className="mt-2 text-sm text-gray-500">
+                  <p>Ocurrió un error inesperado. Por favor, recarga la página.</p>
+                </div>
+                <div className="mt-4">
+                  <button
+                    onClick={() => window.location.reload()}
+                    className="bg-red-600 text-white px-4 py-2 rounded text-sm hover:bg-red-700"
+                  >
+                    Recargar página
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/frontend/src/components/LoadingSpinner.jsx
+++ b/frontend/src/components/LoadingSpinner.jsx
@@ -1,0 +1,19 @@
+export default function LoadingSpinner({ size = 'md', className = '' }) {
+  const sizeClasses = {
+    sm: 'w-4 h-4',
+    md: 'w-8 h-8',
+    lg: 'w-12 h-12'
+  };
+
+  return (
+    <div className={`flex justify-center items-center ${className}`}>
+      <div 
+        className={`animate-spin rounded-full border-2 border-gray-300 border-t-blue-600 ${sizeClasses[size]}`}
+        role="status"
+        aria-label="Cargando"
+      >
+        <span className="sr-only">Cargando...</span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/CMSPublicaciones.jsx
+++ b/frontend/src/pages/CMSPublicaciones.jsx
@@ -1,11 +1,13 @@
 import { useState } from 'react';
 import FormularioPublicacion from '../components/FormularioPublicacion';
+import LoadingSpinner from '../components/LoadingSpinner';
 import usePublicaciones from '../hooks/usePublicaciones';
 
 export default function CMSPublicaciones() {
-  const { publicaciones, load, remove } = usePublicaciones();
+  const { publicaciones, loading, error, load, create, update, remove } = usePublicaciones();
   const [showForm, setShowForm] = useState(false);
   const [editPub, setEditPub] = useState(null);
+  const [deleteLoading, setDeleteLoading] = useState(null);
 
   const handleCreate = () => {
     setEditPub(null);
@@ -19,50 +21,113 @@ export default function CMSPublicaciones() {
 
 
   const handleDelete = async (id) => {
-    if (!confirm('¿Eliminar publicación?')) return;
+    if (!confirm('¿Estás seguro de que quieres eliminar esta publicación?')) return;
+
+    setDeleteLoading(id);
     try {
       await remove(id);
     } catch (err) {
       console.error(err);
-      alert('Error al eliminar');
+      alert('Error al eliminar la publicación');
+    } finally {
+      setDeleteLoading(null);
     }
   };
 
+  const handleCloseForm = () => {
+    setShowForm(false);
+    setEditPub(null);
+  };
+
+  if (loading) {
+    return (
+      <div className="p-4">
+        <h1 className="text-2xl font-bold mb-4">CMS Publicaciones</h1>
+        <LoadingSpinner size="lg" className="py-8" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="p-4">
+        <h1 className="text-2xl font-bold mb-4">CMS Publicaciones</h1>
+        <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded">
+          <p>Error al cargar las publicaciones: {error.message}</p>
+          <button 
+            onClick={load}
+            className="mt-2 bg-red-600 text-white px-3 py-1 rounded text-sm hover:bg-red-700"
+          >
+            Reintentar
+          </button>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <section className="p-4 space-y-4">
-      <h1 className="text-2xl font-bold">CMS Publicaciones</h1>
-      <button onClick={handleCreate} className="px-3 py-1 bg-blue-500 text-white rounded">
-        Nueva publicación
-      </button>
-      <ul className="space-y-2">
-        {publicaciones.map((pub) => (
-          <li key={pub.id} className="border p-2 flex justify-between items-center">
-            <span>{pub.titulo}</span>
-            <div className="space-x-2">
-              <button
-                onClick={() => handleEdit(pub)}
-                className="px-2 py-1 text-sm bg-yellow-500 text-white rounded"
-              >
-                Editar
-              </button>
-              <button
-                onClick={() => handleDelete(pub.id)}
-                className="px-2 py-1 text-sm bg-red-500 text-white rounded"
-              >
-                Eliminar
-              </button>
-            </div>
-          </li>
-        ))}
-      </ul>
+      <div className="flex justify-between items-center">
+        <h1 className="text-2xl font-bold">CMS Publicaciones</h1>
+        <button 
+          onClick={handleCreate} 
+          className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        >
+          Nueva publicación
+        </button>
+      </div>
+
+      {publicaciones.length === 0 ? (
+        <div className="text-center py-8 text-gray-500">
+          <p>No hay publicaciones aún.</p>
+          <p className="text-sm mt-2">Crea la primera publicación usando el botón de arriba.</p>
+        </div>
+      ) : (
+        <div className="bg-white shadow rounded-lg overflow-hidden">
+          <ul className="divide-y divide-gray-200">
+            {publicaciones.map((pub) => (
+              <li key={pub.id} className="p-4 hover:bg-gray-50">
+                <div className="flex justify-between items-center">
+                  <div className="flex-1">
+                    <h3 className="font-semibold text-gray-900">{pub.titulo}</h3>
+                    <p className="text-sm text-gray-600">
+                      {pub.año} • {pub.revista}
+                    </p>
+                  </div>
+                  <div className="flex space-x-2">
+                    <button
+                      onClick={() => handleEdit(pub)}
+                      className="bg-yellow-500 text-white px-3 py-1 rounded text-sm hover:bg-yellow-600 focus:outline-none focus:ring-2 focus:ring-yellow-400"
+                    >
+                      Editar
+                    </button>
+                    <button
+                      onClick={() => handleDelete(pub.id)}
+                      disabled={deleteLoading === pub.id}
+                      className="bg-red-500 text-white px-3 py-1 rounded text-sm hover:bg-red-600 focus:outline-none focus:ring-2 focus:ring-red-400 disabled:opacity-50 disabled:cursor-not-allowed flex items-center"
+                    >
+                      {deleteLoading === pub.id ? (
+                        <>
+                          <LoadingSpinner size="sm" className="mr-1" />
+                          Eliminando...
+                        </>
+                      ) : (
+                        'Eliminar'
+                      )}
+                    </button>
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
       {showForm && (
         <FormularioPublicacion
           publicacion={editPub}
           isEditing={!!editPub}
-          onClose={() => {
-            setShowForm(false);
-            setEditPub(null);
-          }}
+          onClose={handleCloseForm}
           onRefresh={load}
         />
       )}

--- a/frontend/src/pages/Publicaciones.jsx
+++ b/frontend/src/pages/Publicaciones.jsx
@@ -1,67 +1,96 @@
 import { useState } from 'react';
-import FormularioPublicacion from '../components/FormularioPublicacion';
+import LoadingSpinner from '../components/LoadingSpinner';
+import PublicacionCard from '../components/PublicacionCard';
 import usePublicaciones from '../hooks/usePublicaciones';
 import { useAuth } from '../context/AuthContext';
 
 export default function Publicaciones() {
   const { user } = useAuth();
-  const { publicaciones, load, remove } = usePublicaciones();
-  const [showForm, setShowForm] = useState(false);
-  const [editPub, setEditPub] = useState(null);
+  const { publicaciones, loading, error, load } = usePublicaciones();
+  const [searchTerm, setSearchTerm] = useState('');
 
   const canEdit = user && (user.role === 'admin' || user.role === 'editor');
 
+  const filteredPublicaciones = publicaciones.filter(pub =>
+    pub.titulo.toLowerCase().includes(searchTerm.toLowerCase()) ||
+    pub.revista.toLowerCase().includes(searchTerm.toLowerCase())
+  );
+
+  if (loading) {
+    return (
+      <div className="p-4">
+        <h1 className="text-2xl font-bold mb-4">Publicaciones</h1>
+        <LoadingSpinner size="lg" className="py-8" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="p-4">
+        <h1 className="text-2xl font-bold mb-4">Publicaciones</h1>
+        <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded">
+          <p>Error al cargar las publicaciones: {error.message}</p>
+          <button 
+            onClick={load}
+            className="mt-2 bg-red-600 text-white px-3 py-1 rounded text-sm hover:bg-red-700"
+          >
+            Reintentar
+          </button>
+        </div>
+      </div>
+    );
+  }
 
   return (
-    <section className="p-4 space-y-4">
-      <h1 className="text-2xl font-bold">Publicaciones</h1>
-      {canEdit && (
-        <button
-          onClick={() => {
-            setEditPub(null);
-            setShowForm(true);
-          }}
-          className="px-3 py-1 bg-blue-500 text-white rounded"
-        >
-          Nueva publicación
-        </button>
-      )}
-      <ul className="space-y-2">
-        {publicaciones.map((pub) => (
-          <li key={pub.id} className="border p-2 flex justify-between items-center">
-            <span>{pub.titulo}</span>
-            {canEdit && (
-              <div className="space-x-2">
-                <button
-                  onClick={() => {
-                    setEditPub(pub);
-                    setShowForm(true);
-                  }}
-                  className="px-2 py-1 text-sm bg-yellow-500 text-white rounded"
-                >
-                  Editar
-                </button>
-                <button
-                  onClick={() => remove(pub.id)}
-                  className="px-2 py-1 text-sm bg-red-500 text-white rounded"
-                >
-                  Eliminar
-                </button>
-              </div>
-            )}
-          </li>
-        ))}
-      </ul>
-      {showForm && canEdit && (
-        <FormularioPublicacion
-          publicacion={editPub}
-          isEditing={!!editPub}
-          onClose={() => {
-            setShowForm(false);
-            setEditPub(null);
-          }}
-          onRefresh={load}
-        />
+    <section className="p-4 space-y-6">
+      <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
+        <h1 className="text-2xl font-bold">Publicaciones</h1>
+        
+        <div className="flex flex-col sm:flex-row gap-2 w-full sm:w-auto">
+          <input
+            type="text"
+            placeholder="Buscar publicaciones..."
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+            className="px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500 sm:w-64"
+          />
+          {canEdit && (
+            <a
+              href="/cms-publicaciones"
+              className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 text-center"
+            >
+              Gestionar CMS
+            </a>
+          )}
+        </div>
+      </div>
+
+      {publicaciones.length === 0 ? (
+        <div className="text-center py-12 text-gray-500">
+          <svg className="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.746 0 3.332.477 4.5 1.253v13C19.832 18.477 18.246 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
+          </svg>
+          <h3 className="mt-2 text-sm font-medium text-gray-900">No hay publicaciones</h3>
+          <p className="mt-1 text-sm text-gray-500">
+            {canEdit ? 'Comienza agregando tu primera publicación.' : 'Aún no se han publicado artículos.'}
+          </p>
+        </div>
+      ) : filteredPublicaciones.length === 0 ? (
+        <div className="text-center py-12 text-gray-500">
+          <p>No se encontraron publicaciones que coincidan con "{searchTerm}"</p>
+        </div>
+      ) : (
+        <>
+          <div className="text-sm text-gray-600 mb-4">
+            Mostrando {filteredPublicaciones.length} de {publicaciones.length} publicaciones
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {filteredPublicaciones.map((pub) => (
+              <PublicacionCard key={pub.id} pub={pub} />
+            ))}
+          </div>
+        </>
       )}
     </section>
   );


### PR DESCRIPTION
## Summary
- add new `LoadingSpinner` and `ErrorBoundary` components
- enhance CMS Publicaciones with loading/error states and delete feedback
- revamp Publicaciones page with search, loading and error states
- wrap router with `ErrorBoundary`

## Testing
- `npm test` in `backend` *(fails: missing script)*
- `npm test` in `frontend`

------
https://chatgpt.com/codex/tasks/task_e_6852fb040c4083309db139aa040f6c4a