### PR TITLE
Add safer upload handling and headers

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -25,6 +25,7 @@ const publicRoutes = require('./routes/publicRoutes');
 dotenv.config();
 
 const app = express();
+app.disable('x-powered-by');
 const PORT = process.env.PORT || 3000;
 
 // Request logging middleware (antes que todo)
@@ -35,7 +36,7 @@ app.use(helmet({
   contentSecurityPolicy: {
     directives: {
       defaultSrc: ["'self'"],
-      styleSrc: ["'self'", "'unsafe-inline'"],
+      styleSrc: ["'self'"] ,
       scriptSrc: ["'self'"],
       imgSrc: ["'self'", 'data:', 'https:'],
     },

--- a/backend/routes/uploadRoutes.js
+++ b/backend/routes/uploadRoutes.js
@@ -16,7 +16,20 @@ const storage = multer.diskStorage({
   }
 });
 
-const upload = multer({ storage });
+const upload = multer({
+  storage,
+  limits: { fileSize: 5 * 1024 * 1024 }, // 5MB
+  fileFilter: (req, file, cb) => {
+    const allowed = /jpeg|jpg|png|gif/;
+    const ext = path.extname(file.originalname).toLowerCase();
+    const mime = file.mimetype;
+    if (allowed.test(ext) && allowed.test(mime)) {
+      cb(null, true);
+    } else {
+      cb(new Error('Formato de archivo no permitido'));
+    }
+  }
+});
 
 router.post('/upload', verifyToken, isAdminOrEditor, upload.single('image'), (req, res) => {
   const filePath = `/uploads/${req.file.filename}`;


### PR DESCRIPTION
## Summary
- tighten multer with file size limits and type filter
- disable `x-powered-by` header
- limit CSP style sources in Helmet

## Testing
- `npm run lint` in `/workspace/portfolio/backend`
- `npm test` in `/workspace/portfolio/backend` *(fails: Error: no test specified)*
- `npm run lint` in `/workspace/portfolio/frontend`
- `npm test` in `/workspace/portfolio/frontend`


------
https://chatgpt.com/codex/tasks/task_e_68543a6794e48330896715b0a1a64db8